### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/main/java/co/marcin/novaguilds/command/guild/CommandGuildBuyLife.java
+++ b/src/main/java/co/marcin/novaguilds/command/guild/CommandGuildBuyLife.java
@@ -61,7 +61,7 @@ public class CommandGuildBuyLife extends AbstractCommandExecutor {
 
 		List<ItemStack> missingItems = InventoryUtils.getMissingItems(nPlayer.getPlayer().getInventory(), items);
 
-		if(items.size() > 0 && missingItems.size() > 0) {
+		if(!items.isEmpty() && !missingItems.isEmpty()) {
 			Message.CHAT_CREATEGUILD_NOITEMS.send(sender);
 			return;
 		}

--- a/src/main/java/co/marcin/novaguilds/command/guild/CommandGuildBuySlot.java
+++ b/src/main/java/co/marcin/novaguilds/command/guild/CommandGuildBuySlot.java
@@ -70,10 +70,10 @@ public class CommandGuildBuySlot extends AbstractCommandExecutor {
 			return;
 		}
 
-		if(items.size() > 0) {
+		if(!items.isEmpty()) {
 			List<ItemStack> missing = InventoryUtils.getMissingItems(nPlayer.getPlayer().getInventory(), items);
 
-			if(missing.size() > 0) {
+			if(!missing.isEmpty()) {
 				Message.CHAT_CREATEGUILD_NOITEMS.send(sender);
 				sender.sendMessage(StringUtils.getItemList(missing));
 				return;

--- a/src/main/java/co/marcin/novaguilds/command/guild/CommandGuildJoin.java
+++ b/src/main/java/co/marcin/novaguilds/command/guild/CommandGuildJoin.java
@@ -145,7 +145,7 @@ public class CommandGuildJoin extends AbstractCommandExecutor implements Command
 			}
 		}
 
-		if(joinItems.size() > 0) {
+		if(!joinItems.isEmpty()) {
 			InventoryUtils.removeItems((Player) sender, joinItems);
 		}
 

--- a/src/main/java/co/marcin/novaguilds/runnable/RunnableRefreshTabList.java
+++ b/src/main/java/co/marcin/novaguilds/runnable/RunnableRefreshTabList.java
@@ -27,7 +27,7 @@ public class RunnableRefreshTabList implements Runnable {
 	public void run() {
 		TabUtils.refresh();
 
-		if(Bukkit.getOnlinePlayers().size() > 0) {
+		if(!Bukkit.getOnlinePlayers().isEmpty()) {
 			LoggerUtils.info("TabList refreshed (" + Bukkit.getOnlinePlayers().size() + " players)");
 		}
 	}

--- a/src/main/java/co/marcin/novaguilds/util/guiinventory/GUIInventoryGuildRankSettings.java
+++ b/src/main/java/co/marcin/novaguilds/util/guiinventory/GUIInventoryGuildRankSettings.java
@@ -114,7 +114,7 @@ public class GUIInventoryGuildRankSettings extends AbstractGUIInventory {
 			inventory.addItem(deleteItem);
 		}
 
-		if(memberListItem != null && GUIInventoryGuildRankMembers.getMembers(getGuild(), rank).size() > 0) {
+		if(memberListItem != null && !GUIInventoryGuildRankMembers.getMembers(getGuild(), rank).isEmpty()) {
 			inventory.addItem(memberListItem);
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.
