### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/co/marcin/novaguilds/util/ChestGUIUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/ChestGUIUtils.java
@@ -32,6 +32,9 @@ import java.util.List;
 public class ChestGUIUtils {
 	public static final List<NovaPlayer> guiContinueList = new ArrayList<>();
 
+	private ChestGUIUtils() {
+	}
+
 	public static int getChestSize(int count) {
 		return (count / 9) * 9 + (count % 9 == 0 ? 0 : 9);
 	}

--- a/src/main/java/co/marcin/novaguilds/util/IOUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/IOUtils.java
@@ -33,6 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class IOUtils {
+	private IOUtils() {
+	}
+
 	public static String inputStreamToString(InputStream inputStream) {
 		try {
 			return CharStreams.toString(new InputStreamReader(inputStream, "UTF-8"));

--- a/src/main/java/co/marcin/novaguilds/util/InventoryUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/InventoryUtils.java
@@ -31,6 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class InventoryUtils {
+	private InventoryUtils() {
+	}
+
 	public static void removeItems(Player player, List<ItemStack> items) {
 		if(player.getGameMode() != GameMode.CREATIVE) {
 			for(ItemStack item : items) {

--- a/src/main/java/co/marcin/novaguilds/util/ItemStackUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/ItemStackUtils.java
@@ -36,6 +36,9 @@ import java.util.List;
 import java.util.Map;
 
 public final class ItemStackUtils {
+	private ItemStackUtils() {
+	}
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack stringToItemStack(String str) {
 		if(!str.isEmpty()) {

--- a/src/main/java/co/marcin/novaguilds/util/LoggerUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/LoggerUtils.java
@@ -30,6 +30,9 @@ public final class LoggerUtils {
 	private static final Logger logger = Logger.getLogger("Minecraft");
 	private static final NovaGuilds plugin = NovaGuilds.getInstance();
 
+	private LoggerUtils() {
+	}
+
 	public static void error(String error) {
 		logger.severe(StringUtils.fixColors(NovaGuilds.getLogPrefix() + classPrefix() + space(error) + error));
 	}

--- a/src/main/java/co/marcin/novaguilds/util/NumberUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/NumberUtils.java
@@ -21,6 +21,9 @@ package co.marcin.novaguilds.util;
 import java.util.Random;
 
 public final class NumberUtils {
+	private NumberUtils() {
+	}
+
 	public static boolean isNumeric(String str) {
 		return str.matches("[+-]?\\d*(\\.\\d+)?");
 	}

--- a/src/main/java/co/marcin/novaguilds/util/RegionUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/RegionUtils.java
@@ -32,6 +32,9 @@ import java.util.List;
 
 public final class RegionUtils {
 
+	private RegionUtils() {
+	}
+
 	public static List<Block> getBorderBlocks(NovaRegion region) {
 		return getBorderBlocks(region.getCorner(0), region.getCorner(1));
 	}

--- a/src/main/java/co/marcin/novaguilds/util/StringUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/StringUtils.java
@@ -37,6 +37,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public final class StringUtils {
+	private StringUtils() {
+	}
+
 	public static String fixColors(String msg) {
 		if(msg == null) {
 			return null;

--- a/src/main/java/co/marcin/novaguilds/util/TabUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/TabUtils.java
@@ -41,6 +41,9 @@ import java.util.concurrent.TimeUnit;
 public final class TabUtils {
 	private static final NovaGuilds plugin = NovaGuilds.getInstance();
 
+	private TabUtils() {
+	}
+
 	public static void refresh(NovaPlayer nPlayer) {
 		if(!Config.TABLIST_ENABLED.getBoolean()) {
 			return;

--- a/src/main/java/co/marcin/novaguilds/util/TagUtils.java
+++ b/src/main/java/co/marcin/novaguilds/util/TagUtils.java
@@ -34,6 +34,9 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
 public final class TagUtils {
+	private TagUtils() {
+	}
+
 	@SuppressWarnings("deprecation")
 	public static void refresh(Player p) {
 		if(!Config.TAGAPI_ENABLED.getBoolean()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
